### PR TITLE
Possibly controversial suggestions

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -229,7 +229,7 @@ I currently do not have any plans to create a second edition.
 \item[p.\  184] \crucial{in Theorem 9.33,
   uniqueness is not true for (b) or (c).
   The last sentence is also wrong as written.
-  The correct sentence is: if the \emph{circumcircle} of a cyclic quadrilateral is preserved,
+  The correct sentence is: if the \emph{circumcircle} of a cyclic quadrilateral is sent to a circle,
   then so is the cross ratio of the cyclic quadrilateral.}
 \item[p.\  184] in Example 9.34, swap the definitions of $P$, $Q$.
 \item[p.\  184] in solution to Example 9.34,
@@ -282,10 +282,15 @@ I currently do not have any plans to create a second edition.
 \item[p.\  219] \crucial{the dot product is not associative};
   that property does not even make sense for this operation,
   since is an operation from $\RR^n \times \RR^n \to \RR$.
+\item[p.\  221] hint 8, replace ``How you can'' with ``How can you''.
+\item[p.\  221] hint 12 is wrong (see page 268 correction below).
 \item[p.\  222] hint 40, ``It equivalent'' is missing ``is''.
 \item[p.\  222] hint 60, the inequality should be strict.
+\item[p.\  221] hint 66 is wrong (see page 268 correction below).
 \item[p.\  223] hint 77, replace ``$\dang CMN = \dang BMN$''
   with ``$\dang CNM = \dang BNM$''.
+\item[p.\  223] hint 83, replace ``not disjoint'' with
+  ``not disjoint nor neither one is contained inside the other''.
 \item[p.\  223] hint 87, the inequality should be strict.
 \item[p.\  223] hint 93, replace ``at least'' with ``more than''.
 \item[p.\  223] hint 96 is wrong (see page 274 correction below).
@@ -306,7 +311,9 @@ I currently do not have any plans to create a second edition.
 \item[p.\  227] hint 252, replace $O$ with $O^\ast$.
 \item[p.\  228] hint 257, change ``as do $C$ and $F$'' to ``as do $B$ and $D$''.
 \item[p.\  228] hint 267, change $QS$ to $HK$.
-\item[p.\  229] hint 296, in hint 296, ``$H_A = a + b + d$'' chaneg $H_A$ to $h_A$ for consistency.
+\item[p.\  228] hint 274, the definition of point $M$ is missing.
+  Point $M$ is the midpoint of $AB$.
+\item[p.\  229] hint 296, in hint 296, ``$H_A = a + b + d$'' change $H_A$ to $h_A$ for consistency.
 \item[p.\  229] hint 303, change first two instances of $de$ to $bc$.
 \item[p.\  229] hint 304, the comma in $K = (2S_B, 2S_A: -c^2)$ should be a colon, of course.
 \item[p.\  229] hint 316, change ``the circle is'' to ``the circle is centered at''.
@@ -321,6 +328,8 @@ I currently do not have any plans to create a second edition.
 \item[p.\  231] hint 383, ``trigonometric'' is misspelled.
 \item[p.\  231] hint 389, change $L^\ast$ to $A^\ast$.
 \item[p.\  231] hint 393, delete ``$M=(0:1:1)$'' and change the later ``$L$'' to ``$M$''.
+\item[p.\  232] hint 422, the definition of point $T$ is missing.
+  Point $T$ is the contact point of the $A$-mixtilinear incircle.
 \item[p.\  232] hint 425, change ``reflection'' to ``reflections''.
 \item[p.\  233] hint 445, the fraction should be $\frac{(a+b+c)bc}{b^2+bc+c^2}$.
 \item[p.\  233] hint 449, change $A$ to $C$.
@@ -332,6 +341,7 @@ I currently do not have any plans to create a second edition.
 \item[p.\  235] hint 554, change the similarity to $\triangle AOD \sim \triangle CO_1D$.
 \item[p.\  235] \crucial{hint 556 is broken}. I have no memory of what I meant to write.
 \item[p.\  236] hint 571, replace $k$ with $AB$.
+\item[p.\  236] hint 589, change $\dots$ to $\cdots$.
 \item[p.\  236] hint 594, ``midpoint'' should be ``median''.
 \item[p.\  237] hint 616, change the second ``$\omega$'' to ``circle with diameter $\ol{PQ}$''
 \item[p.\  237] hint 633, change $H$ to $M$.
@@ -361,6 +371,8 @@ I currently do not have any plans to create a second edition.
 \item[p.\  264] the footnote calculation appears broken. The correct expression is
   \[ \mathcal{N} - \ol p \mathcal{D}
     = -s_4 \ol p^3 + p^2 \ol p + s_3 \ol p^2 - s_2 \ol p + s_1 - 2 p.  \]
+\item[p.\  265] in Solution 6.45, the first quantity under consideration should be
+  $\frac{a-b}{c-b}\cdot\frac{c-d}{e-d}\cdot\frac{e-f}{a-f}$.
 \item[p.\  265] in Solution 6.45, the solution proves $|(a-b)(c-e)(d-f)|=|(d-e)(f-b)(a-c)|$.
   It should instead prove $|(b-c)(a-e)(f-d)|=|(c-a)(e-f)(d-b)|$,
   which is the same up to permutation of point labels.
@@ -407,6 +419,8 @@ I currently do not have any plans to create a second edition.
     &\qquad+ u(b^2-a^2+c^2) - v(a^2-b^2+c^2) \Big] \\
     &= uvc^2 (b^2-a^2)(u+v-1) = 0.
   \end{align*}
+\item[p.\  269] in Solution 7.47, delete ``Let $\omega_i$ be the circle with center $O_i$ and radius $r_i$''.
+\item[p.\  270] in Solution 7.49, second display, delete ``$\det$''.
 \item[p.\  270] in solution 7.52, $T$ should be $au\inv+bv\inv+cw\inv$.
 \item[p.\  271] in solution 7.52, the line $PC^2 = \dots$ is missing a plus sign after $-a^2(vw)\inv$.
 \item[p.\  271] in solution 7.52, second-to-last display,
@@ -426,11 +440,14 @@ I currently do not have any plans to create a second edition.
 \item[p.\  277] in Solution 9.50, change $\ol{CG} \cap \ol{BE}$ to $\ol{CG'} \cap \ol{BE}$.
 \item[p.\  281] in Solution 10.26, the last line, change $\dang HMN$ to $\dang HNM$.
 \item[p.\  282] in Solution 10.29, change $(P,E;X,Y)$ to $(F,E;X,Y)$ in last paragraph.
+\item[p.\  286] in Solution 11.6, change ``power'' to ``radius''.
 \item[p.\  288] in Solution 11.9, final sentence of second paragraph,
   the tangency is to $(DCM)$, and not $(BCM)$.
 \item[p.\  288] in Solution 11.9, last display, change $\frac{KL}{PL}$ to $\frac{PL}{KL}$.
+\item[p.\  293] in Solution 11.15, change ``the $OPH'$'' to ``$\triangle{OPH'}$''.
 \item[p.\  294] delete the dotted circle in solution 11.16, it shouldn't be there.
-\item[p.\  296] first line, I meant to write $(AQL)$ and not $(ABL)$
+\item[p.\  295] in Solution 11.17, delete ``(where $A_0$ is the tangency point of the incircle on $BC$)''.
+\item[p.\  296] first line, I meant to write $\triangle{AQL}$ and not $(ABL)$
   although these are the same conclusion.
 \item[p.\  296] in Solution 11.18, very very end, change $2t$ to $(b^2+c^2)t$.
 \item[p.\  297] in Solution 11.18, the first display should read


### PR DESCRIPTION
Any suggestion in this proposal might be immediately rejected if you feel it inappropriate.

Additional ToDos:

- Reword p. 126: “It is important that x + y + z = 1 when doing calculations with displacement vectors” should be “… x + y + z = 0 ….”
- Solution to Example 7.30: an abuse of notation in defining the coordinates of point P.
- There is a definition of two circles being orthogonal but no definition of a circle being orthogonal to another circle.
- There is no definition of the complete quadrilateral being cyclic such as the one in _tr011ey_.
- p. 274: ``isogonal with respect to \angle{BAC}'' is undefined in this book.
- Solution 11.11: ``the angle bisector''.
- Solution 10.30: This logic of the first sentence seems very strange to me. The analogous calculation does not imply the second expression and the second one itself will not give the third one. Even if the subject of the relative clause should be interpreted as “the analogous calculation,” which would make some sense to me, the former issue still does not resolve at all. Above all, this introduction might imply that “directed SAS” is going to be used to show the similarity, even though we are going to show accordingly with the definition itself by using cyclic permutations of indices.